### PR TITLE
add ability to output the gem version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Introduction](#introduction)
 - [Installation](#installation)
 - [Usage](#usage)
@@ -93,7 +94,7 @@ You will most likely want to install Attractor using [Bundler][bundler]:
 ```ruby
 gem 'attractor'
 gem 'attractor-ruby'
-gem 'attractor'
+gem 'attractor-javascript'
 ```
 
 And then execute:
@@ -217,7 +218,9 @@ attractor serve
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To run all tests, run `bin/test`. You can run the specs by themselves with `bundle exec rspec`, and the cucumber features with `bundle exec cucumber`.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo "== Running Specs =="
+bundle exec rspec
+echo "== Running Cucumber Features =="
+bundle exec cucumber

--- a/features/attractor.feature
+++ b/features/attractor.feature
@@ -42,3 +42,13 @@ Feature: Attractor
     When I cd to "../../spec/fixtures/rails_app_with_gemfile"
     And I run `attractor serve --ci`
     Then the output should not contain "Opening browser window..."
+
+  Scenario:
+    When I cd to "../../spec/fixtures/rails_app_with_gemfile"
+    And I run `attractor -v`
+    Then the output should contain "Attractor version"
+
+  Scenario:
+    When I cd to "../../spec/fixtures/rails_app_with_gemfile"
+    And I run `attractor --version`
+    Then the output should contain "Attractor version"

--- a/lib/attractor/cli.rb
+++ b/lib/attractor/cli.rb
@@ -17,6 +17,14 @@ module Attractor
                         [:no_open_browser, type: :boolean],
                         [:ci, type: :boolean]]
 
+    desc "version", "Prints Attractor's version information"
+    map %w(-v --version) => :version
+    def version
+      puts "Attractor version #{Attractor::VERSION}"
+    rescue RuntimeError => e
+      puts "Runtime error: #{e.message}"
+    end
+
     desc 'calc', 'Calculates churn and complexity for all ruby files in current directory'
     shared_options.each do |shared_option|
       option(*shared_option)


### PR DESCRIPTION
Using the -v or --version flag in the CLI will now output the version of the gem. This is needed for julianrubisch/attractor-action#4 so we can easily  confirm whether we need to verify plugins are present or not.