### PR TITLE
Add an "--ignore" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ attractor calc
   --watch|-w
   --start_ago|-s  (e.g. 5y, 3m, 7w)
   --minimum_churn|-c (minimum times a file must have changed to be processed)
+  --ignore|-i 'spec/*_spec.rb,db/schema.rb,tmp'
 ```
 
 Generate a full report
@@ -207,6 +208,7 @@ attractor report
   --no-open-browser|--ci
   --start_ago|-s  (e.g. 5y, 3m, 7w)
   --minimum_churn|-c (minimum times a file must have changed to be processed)
+  --ignore|-i 'spec/*_spec.rb,db/schema.rb,tmp'
 ```
 
 Serve the output on `http://localhost:7890`
@@ -218,6 +220,7 @@ attractor serve
   --no-open-browser|--ci
   --start_ago|-s  (e.g. 5y, 3m, 7w)
   --minimum_churn|-c (minimum times a file must have changed to be processed)
+  --ignore|-i 'spec/*_spec.rb,db/schema.rb,tmp'
 ```
 
 ## Development

--- a/attractor.gemspec
+++ b/attractor.gemspec
@@ -50,8 +50,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tilt"
 
   spec.add_development_dependency "aruba"
-  spec.add_development_dependency "attractor-javascript"
-  spec.add_development_dependency "attractor-ruby"
+  spec.add_development_dependency "attractor-javascript", "~> 0.2.0"
+  spec.add_development_dependency "attractor-ruby", "~> 0.2.0"
   spec.add_development_dependency "autoprefixer-rails"
   spec.add_development_dependency "bootstrap", "~> 4.3.1"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/attractor/calculators/base_calculator.rb
+++ b/lib/attractor/calculators/base_calculator.rb
@@ -9,11 +9,12 @@ module Attractor
   class BaseCalculator
     attr_reader :type
 
-    def initialize(file_prefix: "", file_extension: "rb", minimum_churn_count: 3, start_ago: "5y")
+    def initialize(file_prefix: "", ignores: "", file_extension: "rb", minimum_churn_count: 3, start_ago: "5y")
       @file_prefix = file_prefix
       @file_extension = file_extension
       @minimum_churn_count = minimum_churn_count
       @start_date = Date.today - Attractor::DurationParser.new(start_ago).duration
+      @ignores = ignores
     end
 
     def calculate
@@ -21,7 +22,8 @@ module Attractor
         file_extension: @file_extension,
         file_prefix: @file_prefix,
         minimum_churn_count: @minimum_churn_count,
-        start_date: @start_date
+        start_date: @start_date,
+        ignores: @ignores
       ).report(false)
 
       churn[:churn][:changes].map do |change|

--- a/lib/attractor/cli.rb
+++ b/lib/attractor/cli.rb
@@ -8,6 +8,7 @@ module Attractor
   # contains methods implementing the CLI
   class CLI < Thor
     shared_options = [[:file_prefix, aliases: :p],
+      [:ignore, aliases: :i, default: ""],
       [:watch, aliases: :w, type: :boolean],
       [:minimum_churn, aliases: :c, type: :numeric, default: 3],
       [:start_ago, aliases: :s, type: :string, default: "5y"],
@@ -32,7 +33,7 @@ module Attractor
     def calc
       file_prefix = options[:file_prefix]
 
-      report! Attractor::ConsoleReporter.new(file_prefix: file_prefix, calculators: calculators(options))
+      report! Attractor::ConsoleReporter.new(file_prefix: file_prefix, ignores: options[:ignore], calculators: calculators(options))
     rescue RuntimeError => e
       puts "Runtime error: #{e.message}"
     end
@@ -45,7 +46,7 @@ module Attractor
       file_prefix = options[:file_prefix]
       open_browser = !(options[:no_open_browser] || options[:ci])
 
-      report! Attractor::HtmlReporter.new(file_prefix: file_prefix, calculators: calculators(options), open_browser: open_browser)
+      report! Attractor::HtmlReporter.new(file_prefix: file_prefix, ignores: options[:ignore], calculators: calculators(options), open_browser: open_browser)
     rescue RuntimeError => e
       puts "Runtime error: #{e.message}"
     end
@@ -58,7 +59,7 @@ module Attractor
       file_prefix = options[:file_prefix]
       open_browser = !(options[:no_open_browser] || options[:ci])
 
-      report! Attractor::SinatraReporter.new(file_prefix: file_prefix, calculators: calculators(options), open_browser: open_browser)
+      report! Attractor::SinatraReporter.new(file_prefix: file_prefix, ignores: options[:ignore], calculators: calculators(options), open_browser: open_browser)
     end
 
     private
@@ -67,6 +68,7 @@ module Attractor
       Attractor.calculators_for_type(options[:type],
         file_prefix: options[:file_prefix],
         minimum_churn_count: options[:minimum_churn],
+        ignores: options[:ignore],
         start_ago: options[:start_ago])
     end
 

--- a/lib/attractor/reporters/base_reporter.rb
+++ b/lib/attractor/reporters/base_reporter.rb
@@ -15,14 +15,14 @@ module Attractor
     attr_writer :values
     def_delegator :@watcher, :watch
 
-    def initialize(file_prefix:, calculators:, open_browser: true)
+    def initialize(calculators:, file_prefix: "", ignores: "", open_browser: true)
       @file_prefix = file_prefix || ""
       @calculators = calculators
       @open_browser = open_browser
       @values = @calculators.first.last.calculate
       @suggester = Suggester.new(values)
 
-      @watcher = Watcher.new(@file_prefix, lambda do
+      @watcher = Watcher.new(@file_prefix, ignores, lambda do
         report
       end)
     rescue NoMethodError => _e

--- a/lib/attractor/watcher.rb
+++ b/lib/attractor/watcher.rb
@@ -5,15 +5,17 @@ require "listen"
 module Attractor
   # functionality for watching file system changes
   class Watcher
-    def initialize(file_prefix, callback)
+    def initialize(file_prefix, ignores, callback)
       @file_prefix = file_prefix
       @callback = callback
+      @ignores = ignores.split(",").map(&:strip)
     end
 
     def watch
       @callback.call
+      ignore = @ignores + [/^attractor_output/]
 
-      listener = Listen.to(File.absolute_path(@file_prefix), ignore: /^attractor_output/) do |modified, _added, _removed|
+      listener = Listen.to(File.absolute_path(@file_prefix), ignore: ignore) do |modified, _added, _removed|
         if modified
           puts "#{modified.map(&:to_s).join(", ")} modified, recalculating..."
           @callback.call

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Attractor::Watcher do
   it "can be instantiated" do
-    described_class.new(".", -> {})
+    described_class.new(".", "", -> {})
   end
 
   # it ":watch can be called" do


### PR DESCRIPTION
This PR adds an `--ignore` option to Attractor, so one can:

```
attractor <action> --ignore bloated.rb,some_dir,another_thing/to/ignore.js
```

~~Its implementation won't work yet with `--watch` option (see #91)~~

This can be considered as a **version breaker** as the API for `BaseCalculator.initialize` changes with the new `ignore` parameter : all other calculators should be updated to add this parameter too.

```rb
# attractor-javascript/lib/attractor/calculators/js_calculator.rb
# attractor-ruby/lib/attractor/calculators/js_calculator.rb
def initialize(file_prefix: '', ignores: '', minimum_churn_count: 3, start_ago: 365 * 5)
  super(file_prefix: file_prefix, file_extension: '(js|jsx)', ignores: ignores, minimum_churn_count: minimum_churn_count, start_ago: start_ago)
  # ...
end
```
Note: it won't be such an issue if we could have called super with all args, maybe like:

```rb
def initialize(options)
  options[:file_extension] = '(js|jsx)'
  super(options)
end
```

Closes #90