### PR TITLE
Allow to warm and clear attractor's cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ attractor:
 
 ## CLI Commands and Options
 
+Initialize the local cache:
+
+```sh
+attractor init
+  --file_prefix|-p app/models
+  --type|-t rb|js
+  --start_ago|-s  (e.g. 5y, 3m, 7w)
+  --minimum_churn|-c (minimum times a file must have changed to be processed)
+  --ignore|-i 'spec/*_spec.rb,db/schema.rb,tmp'
+``` 
+
 Print a simple output to console:
 
 ```sh
@@ -222,6 +233,13 @@ attractor serve
   --minimum_churn|-c (minimum times a file must have changed to be processed)
   --ignore|-i 'spec/*_spec.rb,db/schema.rb,tmp'
 ```
+
+Clear the local cache:
+
+```sh
+attractor clean
+``` 
+
 
 ## Development
 

--- a/features/attractor.feature
+++ b/features/attractor.feature
@@ -10,7 +10,7 @@ Feature: Attractor
 
   Scenario:
     When I cd to "../../spec/fixtures/rails_app_with_gemfile"
-    And I run `attractor report --format html`
+    And I run `attractor report`
     # Then an HTML file should be generated
     Then the output should contain "Generated HTML report at"
     Then the output should contain "attractor_output/index.rb.html"
@@ -57,3 +57,9 @@ Feature: Attractor
     When I cd to "../../spec/fixtures/rails_app_with_gemfile"
     And I run `attractor clean`
     Then the output should contain "Clearing attractor cache"
+
+  Scenario:
+    When I cd to "../../spec/fixtures/rails_app_with_gemfile"
+    And I run `attractor init`
+    Then the output should contain "Warming attractor cache"
+    Then the output should contain "Calculating"

--- a/features/attractor.feature
+++ b/features/attractor.feature
@@ -52,3 +52,8 @@ Feature: Attractor
     When I cd to "../../spec/fixtures/rails_app_with_gemfile"
     And I run `attractor --version`
     Then the output should contain "Attractor version"
+
+  Scenario:
+    When I cd to "../../spec/fixtures/rails_app_with_gemfile"
+    And I run `attractor clean`
+    Then the output should contain "Clearing attractor cache"

--- a/lib/attractor.rb
+++ b/lib/attractor.rb
@@ -21,6 +21,15 @@ module Attractor
 
   @registry_entries = {}
 
+  def init(calculators)
+    calculators ||= all_registered_calculators
+    calculators.to_a.map(&:last).each(&:calculate)
+  end
+
+  def clear
+    Cache.clear
+  end
+
   def register(registry_entry)
     @registry_entries[registry_entry.type] = registry_entry
   end
@@ -30,13 +39,20 @@ module Attractor
 
     return {type => registry_entry_for_type.calculator_class.new(**options)} if type
 
+    all_registered_calculators(**options)
+  end
+
+  def all_registered_calculators(options = {})
     Hash[@registry_entries.map do |type, entry|
       [type, entry.calculator_class.new(**options)] if entry.detector_class.new.detect
     end.compact]
   end
 
   module_function :calculators_for_type
+  module_function :all_registered_calculators
   module_function :register
+  module_function :init
+  module_function :clear
 end
 
 Attractor::GemNames.new.to_a.each do |gem_name|

--- a/lib/attractor/cache.rb
+++ b/lib/attractor/cache.rb
@@ -14,6 +14,10 @@ module Attractor
         adapter.write(file_path: file_path, value: value)
       end
 
+      def persist!
+        adapter.persist!
+      end
+
       def clear
         adapter.clear
       end
@@ -60,6 +64,9 @@ module Attractor
 
         transformed_value = value.to_h.transform_keys { |k| mappings[k] || k }
         @store[file_path] = {value.current_commit => transformed_value}
+      end
+
+      def persist!
         File.write(filename, ::JSON.dump(@store))
       end
 

--- a/lib/attractor/cache.rb
+++ b/lib/attractor/cache.rb
@@ -14,6 +14,10 @@ module Attractor
         adapter.write(file_path: file_path, value: value)
       end
 
+      def clear
+        adapter.clear
+      end
+
       private
 
       def adapter
@@ -57,6 +61,10 @@ module Attractor
         transformed_value = value.to_h.transform_keys { |k| mappings[k] || k }
         @store[file_path] = {value.current_commit => transformed_value}
         File.write(filename, ::JSON.dump(@store))
+      end
+
+      def clear
+        FileUtils.rm filename
       end
 
       def filename

--- a/lib/attractor/calculators/base_calculator.rb
+++ b/lib/attractor/calculators/base_calculator.rb
@@ -26,7 +26,9 @@ module Attractor
         ignores: @ignores
       ).report(false)
 
-      churn[:churn][:changes].map do |change|
+      puts "Calculating churn and complexity values for #{churn[:churn][:changes].size} #{type} files"
+
+      values = churn[:churn][:changes].map do |change|
         history = git_history_for_file(file_path: change[:file_path])
         commit = history&.first&.first
 
@@ -45,8 +47,15 @@ module Attractor
           Cache.write(file_path: change[:file_path], value: value)
         end
 
+        print "."
         value
       end
+
+      Cache.persist!
+
+      print "\n\n"
+
+      values
     end
 
     private

--- a/lib/attractor/cli.rb
+++ b/lib/attractor/cli.rb
@@ -32,6 +32,15 @@ module Attractor
       Cache.clear
     end
 
+    desc "init", "Initializes attractor's cache"
+    shared_options.each do |shared_option|
+      option(*shared_option)
+    end
+    def init
+      puts "Warming attractor cache"
+      calculators(options).each { |calc| calc.last.calculate }
+    end
+
     desc "calc", "Calculates churn and complexity for all ruby files in current directory"
     shared_options.each do |shared_option|
       option(*shared_option)

--- a/lib/attractor/cli.rb
+++ b/lib/attractor/cli.rb
@@ -26,6 +26,12 @@ module Attractor
       puts "Runtime error: #{e.message}"
     end
 
+    desc "clean", "Clears attractor's cache"
+    def clean
+      puts "Clearing attractor cache"
+      Cache.clear
+    end
+
     desc "calc", "Calculates churn and complexity for all ruby files in current directory"
     shared_options.each do |shared_option|
       option(*shared_option)

--- a/lib/attractor/cli.rb
+++ b/lib/attractor/cli.rb
@@ -29,7 +29,7 @@ module Attractor
     desc "clean", "Clears attractor's cache"
     def clean
       puts "Clearing attractor cache"
-      Cache.clear
+      Attractor.clear
     end
 
     desc "init", "Initializes attractor's cache"
@@ -38,7 +38,7 @@ module Attractor
     end
     def init
       puts "Warming attractor cache"
-      calculators(options).each { |calc| calc.last.calculate }
+      Attractor.init(calculators(options))
     end
 
     desc "calc", "Calculates churn and complexity for all ruby files in current directory"

--- a/lib/attractor/duration_parser.rb
+++ b/lib/attractor/duration_parser.rb
@@ -14,7 +14,9 @@ module Attractor
 
     def initialize(input)
       @input = input
-      @duration = 0
+      @duration = @input.is_a?(Numeric) ? @input : 0
+      return if @duration > 0
+
       parse
     end
 

--- a/lib/attractor/reporters/base_reporter.rb
+++ b/lib/attractor/reporters/base_reporter.rb
@@ -19,7 +19,6 @@ module Attractor
       @file_prefix = file_prefix || ""
       @calculators = calculators
       @open_browser = open_browser
-      @values = @calculators.first.last.calculate
       @suggester = Suggester.new(values)
 
       @watcher = Watcher.new(@file_prefix, ignores, lambda do


### PR DESCRIPTION
This PR adds the possibility to warm the cache using

```sh
attractor init
```

which also takes the usual options (type, file prefix etc.) and to clear it again using

```sh
attractor clear
```


Also available via module functions `Attractor.clear` and `Attractor.init` which should make it easy to build a rake task for `attractor-rails`